### PR TITLE
Send email in the worker dyno using celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: python3 -m mailer
+worker: celery worker --app=tasks.app --concurrency=1

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,6 @@
 # XXX: Somewhere after 2.x, aiohttp made a change that breaks our tests
 aiohttp<3
 aiosmtplib
+celery
+redis
+cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
 multidict==4.5.2          # via aiohttp, yarl
 yarl==1.3.0               # via aiohttp
+redis==3.5.3
+celery==4.4.6
+cachetools==4.1.1

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+
+import cachetools
+import celery
+
+app = celery.Celery("send_cpython_email")
+
+app.conf.update(
+    BROKER_URL=os.environ["REDIS_URL"], CELERY_RESULT_BACKEND=os.environ["REDIS_URL"]
+)
+
+cache = cachetools.LRUCache(maxsize=500)
+
+SMTP_USERNAME = os.environ.get("SMTP_USERNAME")
+SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD")
+
+
+@app.task()
+def send_email_task(smtp, message):
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(send_email(smtp, message))
+
+
+async def send_email(smtp, message):
+    async with smtp as server:
+        await server.connect()
+        # Call ehlo() as a workaround for cole/aiosmtplib/#13.
+        await server.ehlo()
+        if SMTP_USERNAME is not None and SMTP_PASSWORD is not None:
+            await server.login(SMTP_USERNAME, SMTP_PASSWORD)
+        return await server.send_message(message)


### PR DESCRIPTION
We received timeouts in Heroku, it seems like sending email is taking longer time then Heroku is willing to await.
I've refactored the code so sending email will be done as a celery task.

Before deploying, we need to add the "worker" dyno in Heroku, and add redis broker.

I can help set it up in Heroku side, this should work the same way as miss-islington.

Fixes https://github.com/berkerpeksag/cpython-emailer-webhook/issues/12
